### PR TITLE
Put back header-item slot in mdTabs

### DIFF
--- a/src/components/mdTabs/mdTabs.vue
+++ b/src/components/mdTabs/mdTabs.vue
@@ -15,13 +15,15 @@
             <md-ink-ripple :md-disabled="header.disabled"></md-ink-ripple>
 
             <div class="md-tab-header-container">
-              <md-icon v-if="header.icon">{{ header.icon }}</md-icon>
-              <md-icon v-else-if="header.iconset" :md-iconset="header.iconset">{{ header.icon }}</md-icon>
-              <md-icon v-else-if="header.iconSrc" :md-src="header.iconSrc"></md-icon>
+              <slot name="header-item" :header="header">
+                <md-icon v-if="header.icon">{{ header.icon }}</md-icon>
+                <md-icon v-else-if="header.iconset" :md-iconset="header.iconset">{{ header.icon }}</md-icon>
+                <md-icon v-else-if="header.iconSrc" :md-src="header.iconSrc"></md-icon>
 
-              <span v-if="header.label">{{ header.label }}</span>
+                <span v-if="header.label">{{ header.label }}</span>
 
-              <md-tooltip v-if="header.tooltip" :md-direction="header.tooltipDirection" :md-delay="header.tooltipDelay">{{ header.tooltip }}</md-tooltip>
+                <md-tooltip v-if="header.tooltip" :md-direction="header.tooltipDirection" :md-delay="header.tooltipDelay">{{ header.tooltip }}</md-tooltip>
+              </slot>
             </div>
           </button>
 


### PR DESCRIPTION
Initially implemented in PR #596 but was removed in commit 500e5b5.
This also fixes issue #896.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
